### PR TITLE
Add ability to control whether ping extension is advertised

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	golang.org/x/net v0.21.0 // tagx:ignore
-	golang.org/x/sys v0.22.0
-	golang.org/x/term v0.22.0
+	golang.org/x/sys v0.23.0
+	golang.org/x/term v0.23.0
 )
 
-require golang.org/x/text v0.16.0 // indirect
+require golang.org/x/text v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
-golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
-golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
-golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
+golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
+golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=

--- a/ssh/cipher_test.go
+++ b/ssh/cipher_test.go
@@ -22,7 +22,7 @@ func TestDefaultCiphersExist(t *testing.T) {
 			t.Errorf("supported cipher %q is unknown", cipherAlgo)
 		}
 	}
-	for _, cipherAlgo := range preferredCiphers {
+	for _, cipherAlgo := range PreferredCiphers {
 		if _, ok := cipherModes[cipherAlgo]; !ok {
 			t.Errorf("preferred cipher %q is unknown", cipherAlgo)
 		}

--- a/ssh/client_auth.go
+++ b/ssh/client_auth.go
@@ -72,7 +72,7 @@ func (c *connection) clientAuthenticate(config *ClientConfig) error {
 		ok, methods, err := auth.auth(sessionID, config.User, c.transport, config.Rand, extensions)
 		if err != nil {
 			// On disconnect, return error immediately
-			if _, ok := err.(*disconnectMsg); ok {
+			if _, ok := err.(*DisconnectError); ok {
 				return err
 			}
 			// We return the error later if there is no other method left to

--- a/ssh/client_auth_test.go
+++ b/ssh/client_auth_test.go
@@ -613,7 +613,7 @@ func TestClientAuthMaxAuthTries(t *testing.T) {
 	}
 	serverConfig.AddHostKey(testSigners["rsa"])
 
-	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &disconnectMsg{
+	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &DisconnectError{
 		Reason:  2,
 		Message: "too many authentication failures",
 	})
@@ -676,7 +676,7 @@ func TestClientAuthMaxAuthTriesPublicKey(t *testing.T) {
 		t.Fatalf("unable to dial remote side: %s", err)
 	}
 
-	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &disconnectMsg{
+	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &DisconnectError{
 		Reason:  2,
 		Message: "too many authentication failures",
 	})

--- a/ssh/client_test.go
+++ b/ssh/client_test.go
@@ -292,7 +292,7 @@ func TestUnsupportedAlgorithm(t *testing.T) {
 		{
 			"unsupported and supported KEXs",
 			Config{
-				KeyExchanges: []string{"unsupported", kexAlgoCurve25519SHA256},
+				KeyExchanges: []string{"unsupported", KexAlgoCurve25519SHA256},
 			},
 			"",
 		},

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -34,8 +34,8 @@ var supportedCiphers = []string{
 	tripledescbcID,
 }
 
-// preferredCiphers specifies the default preference for ciphers.
-var preferredCiphers = []string{
+// PreferredCiphers specifies the default preference for ciphers.
+var PreferredCiphers = []string{
 	"aes128-gcm@openssh.com", gcm256CipherID,
 	chacha20Poly1305ID,
 	"aes128-ctr", "aes192-ctr", "aes256-ctr",
@@ -59,10 +59,10 @@ var serverForbiddenKexAlgos = map[string]struct{}{
 	kexAlgoDHGEXSHA256: {}, // server half implementation is only minimal to satisfy the automated tests
 }
 
-// preferredKexAlgos specifies the default preference for key-exchange
+// PreferredKexAlgos specifies the default preference for key-exchange
 // algorithms in preference order. The diffie-hellman-group16-sha512 algorithm
 // is disabled by default because it is a bit slower than the others.
-var preferredKexAlgos = []string{
+var PreferredKexAlgos = []string{
 	kexAlgoCurve25519SHA256, kexAlgoCurve25519SHA256LibSSH,
 	kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
 	kexAlgoDH14SHA256, kexAlgoDH14SHA1,
@@ -297,7 +297,7 @@ func (c *Config) SetDefaults() {
 		c.Rand = rand.Reader
 	}
 	if c.Ciphers == nil {
-		c.Ciphers = preferredCiphers
+		c.Ciphers = PreferredCiphers
 	}
 	var ciphers []string
 	for _, c := range c.Ciphers {
@@ -309,7 +309,7 @@ func (c *Config) SetDefaults() {
 	c.Ciphers = ciphers
 
 	if c.KeyExchanges == nil {
-		c.KeyExchanges = preferredKexAlgos
+		c.KeyExchanges = PreferredKexAlgos
 	}
 	var kexs []string
 	for _, k := range c.KeyExchanges {

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -44,28 +44,28 @@ var PreferredCiphers = []string{
 // supportedKexAlgos specifies the supported key-exchange algorithms in
 // preference order.
 var supportedKexAlgos = []string{
-	kexAlgoCurve25519SHA256, kexAlgoCurve25519SHA256LibSSH,
+	KexAlgoCurve25519SHA256, KexAlgoCurve25519SHA256LibSSH,
 	// P384 and P521 are not constant-time yet, but since we don't
 	// reuse ephemeral keys, using them for ECDH should be OK.
-	kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
-	kexAlgoDH14SHA256, kexAlgoDH16SHA512, kexAlgoDH14SHA1,
-	kexAlgoDH1SHA1,
+	KexAlgoECDH256, KexAlgoECDH384, KexAlgoECDH521,
+	KexAlgoDH14SHA256, KexAlgoDH16SHA512, KexAlgoDH14SHA1,
+	KexAlgoDH1SHA1,
 }
 
 // serverForbiddenKexAlgos contains key exchange algorithms, that are forbidden
 // for the server half.
 var serverForbiddenKexAlgos = map[string]struct{}{
-	kexAlgoDHGEXSHA1:   {}, // server half implementation is only minimal to satisfy the automated tests
-	kexAlgoDHGEXSHA256: {}, // server half implementation is only minimal to satisfy the automated tests
+	KexAlgoDHGEXSHA1:   {}, // server half implementation is only minimal to satisfy the automated tests
+	KexAlgoDHGEXSHA256: {}, // server half implementation is only minimal to satisfy the automated tests
 }
 
 // PreferredKexAlgos specifies the default preference for key-exchange
 // algorithms in preference order. The diffie-hellman-group16-sha512 algorithm
 // is disabled by default because it is a bit slower than the others.
 var PreferredKexAlgos = []string{
-	kexAlgoCurve25519SHA256, kexAlgoCurve25519SHA256LibSSH,
-	kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
-	kexAlgoDH14SHA256, kexAlgoDH14SHA1,
+	KexAlgoCurve25519SHA256, KexAlgoCurve25519SHA256LibSSH,
+	KexAlgoECDH256, KexAlgoECDH384, KexAlgoECDH521,
+	KexAlgoDH14SHA256, KexAlgoDH14SHA1,
 }
 
 // supportedHostKeyAlgos specifies the supported host-key algorithms (i.e. methods

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -287,6 +287,9 @@ type Config struct {
 	// The allowed MAC algorithms. If unspecified then a sensible default is
 	// used. Unsupported values are silently ignored.
 	MACs []string
+
+	// Control whether the ping extension is advertised to clients.
+	DisablePingExtension bool
 }
 
 // SetDefaults sets sensible values for unset fields in config. This is

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -95,6 +95,10 @@ type Conn interface {
 	// connection will hang.
 	OpenChannel(name string, data []byte) (Channel, <-chan *Request, error)
 
+	// Disconnect sends a message to explicitly close the connection.  After
+	// this has been called, no further messages can be sent.
+	Disconnect(reason DisconnectReason, message string) error
+
 	// Close closes the underlying network connection
 	Close() error
 
@@ -103,10 +107,6 @@ type Conn interface {
 	// explicit disconnect message from the other end, then Wait will return a
 	// DisconnectError.
 	Wait() error
-
-	// TODO(hanwen): consider exposing:
-	//   RequestKeyChange
-	//   Disconnect
 }
 
 // DiscardRequests consumes and rejects all requests from the

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -84,11 +84,11 @@ type RawConn interface {
 	ConnMetadata
 
 	// SendMessage sends a single RFC 4254 connection level message.
-	SendMessage(msg interface{}) error
+	SendMessage(msg Message) error
 
 	// ReceiveMessage blocks until it can return a single connection level
 	// message.
-	ReceiveMessage() (interface{}, error)
+	ReceiveMessage() (Message, error)
 
 	// Disconnect sends a message to explicitly close the connection.  After
 	// this has been called, no further messages can be sent.
@@ -97,6 +97,40 @@ type RawConn interface {
 	// Close closes the underlying network connection.
 	Close() error
 }
+
+type GlobalRequestMsg = globalRequestMsg
+type GlobalRequestSuccessMsg = globalRequestSuccessMsg
+type GlobalRequestFailureMsg = globalRequestFailureMsg
+type ChannelOpenMsg = channelOpenMsg
+type ChannelOpenConfirmMsg = channelOpenConfirmMsg
+type ChannelOpenFailureMsg = channelOpenFailureMsg
+type ChannelDataMsg = channelDataMsg
+type ChannelExtendedDataMsg = channelExtendedDataMsg
+type ChannelWindowAdjustMsg = windowAdjustMsg
+type ChannelEOFMsg = channelEOFMsg
+type ChannelRequestMsg = channelRequestMsg
+type ChannelRequestSuccessMsg = channelRequestSuccessMsg
+type ChannelRequestFailureMsg = channelRequestFailureMsg
+type ChannelCloseMsg = channelCloseMsg
+
+type Message interface {
+	isMessageMarker()
+}
+
+func (_ *GlobalRequestMsg) isMessageMarker()         {}
+func (_ *GlobalRequestSuccessMsg) isMessageMarker()  {}
+func (_ *GlobalRequestFailureMsg) isMessageMarker()  {}
+func (_ *ChannelOpenMsg) isMessageMarker()           {}
+func (_ *ChannelOpenConfirmMsg) isMessageMarker()    {}
+func (_ *ChannelOpenFailureMsg) isMessageMarker()    {}
+func (_ *ChannelDataMsg) isMessageMarker()           {}
+func (_ *ChannelExtendedDataMsg) isMessageMarker()   {}
+func (_ *ChannelWindowAdjustMsg) isMessageMarker()   {}
+func (_ *ChannelEOFMsg) isMessageMarker()            {}
+func (_ *ChannelRequestMsg) isMessageMarker()        {}
+func (_ *ChannelRequestSuccessMsg) isMessageMarker() {}
+func (_ *ChannelRequestFailureMsg) isMessageMarker() {}
+func (_ *ChannelCloseMsg) isMessageMarker()          {}
 
 // Conn represents an SSH connection for both server and client roles.
 // Conn is the basis for implementing an application layer, such
@@ -150,17 +184,26 @@ type connection struct {
 	*mux
 }
 
-func (c *connection) SendMessage(msg interface{}) error {
+func (c *connection) SendMessage(msg Message) error {
 	packet := Marshal(msg)
 	return c.transport.writePacket(packet)
 }
 
-func (c *connection) ReceiveMessage() (interface{}, error) {
+func (c *connection) ReceiveMessage() (Message, error) {
 	packet, err := c.transport.readPacket()
 	if err != nil {
 		return nil, err
 	}
-	return decode(packet)
+	msg, err := decode(packet)
+	if err != nil {
+		return nil, err
+	}
+
+	if msg, ok := msg.(Message); !ok {
+		return nil, fmt.Errorf("Not a valid connection message: %T", msg)
+	} else {
+		return msg, nil
+	}
 }
 
 func (c *connection) Disconnect(reason DisconnectReason, message string) error {

--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -698,18 +698,25 @@ func (t *handshakeTransport) enterKeyExchange(otherInitPacket []byte) error {
 	// RFC 8308, Sections 2.4 and 3.1, and [PROTOCOL], Section 1.9.
 	if !isClient && firstKeyExchange && contains(clientInit.KexAlgos, "ext-info-c") {
 		supportedPubKeyAuthAlgosList := strings.Join(t.publicKeyAuthAlgorithms, ",")
+		payloadSize := 4+15+4+len(supportedPubKeyAuthAlgosList)
+		if !t.config.DisablePingExtension {
+			payloadSize += 4+16+4+1
+		}
 		extInfo := &extInfoMsg{
-			NumExtensions: 2,
-			Payload:       make([]byte, 0, 4+15+4+len(supportedPubKeyAuthAlgosList)+4+16+4+1),
+			NumExtensions: 1,
+			Payload:       make([]byte, 0, payloadSize),
 		}
 		extInfo.Payload = appendInt(extInfo.Payload, len("server-sig-algs"))
 		extInfo.Payload = append(extInfo.Payload, "server-sig-algs"...)
 		extInfo.Payload = appendInt(extInfo.Payload, len(supportedPubKeyAuthAlgosList))
 		extInfo.Payload = append(extInfo.Payload, supportedPubKeyAuthAlgosList...)
-		extInfo.Payload = appendInt(extInfo.Payload, len("ping@openssh.com"))
-		extInfo.Payload = append(extInfo.Payload, "ping@openssh.com"...)
-		extInfo.Payload = appendInt(extInfo.Payload, 1)
-		extInfo.Payload = append(extInfo.Payload, "0"...)
+		if !t.config.DisablePingExtension {
+			extInfo.NumExtensions++
+			extInfo.Payload = appendInt(extInfo.Payload, len("ping@openssh.com"))
+			extInfo.Payload = append(extInfo.Payload, "ping@openssh.com"...)
+			extInfo.Payload = appendInt(extInfo.Payload, 1)
+			extInfo.Payload = append(extInfo.Payload, "0"...)
+		}
 		if err := t.conn.writePacket(Marshal(extInfo)); err != nil {
 			return err
 		}

--- a/ssh/handshake_test.go
+++ b/ssh/handshake_test.go
@@ -511,11 +511,15 @@ func TestDisconnect(t *testing.T) {
 	defer trS.Close()
 
 	trC.writePacket([]byte{msgRequestSuccess, 0, 0})
-	errMsg := &disconnectMsg{
+	errPacket := &disconnectMsg{
 		Reason:  42,
 		Message: "such is life",
 	}
-	trC.writePacket(Marshal(errMsg))
+	errResponse := &DisconnectError{
+		Reason:  DisconnectReason(errPacket.Reason),
+		Message: errPacket.Message,
+	}
+	trC.writePacket(Marshal(errPacket))
 	trC.writePacket([]byte{msgRequestSuccess, 0, 0})
 
 	packet, err := trS.readPacket()
@@ -529,8 +533,8 @@ func TestDisconnect(t *testing.T) {
 	_, err = trS.readPacket()
 	if err == nil {
 		t.Errorf("readPacket 2 succeeded")
-	} else if !reflect.DeepEqual(err, errMsg) {
-		t.Errorf("got error %#v, want %#v", err, errMsg)
+	} else if !reflect.DeepEqual(err, errResponse) {
+		t.Errorf("got error %#v, want %#v", err, errResponse)
 	}
 
 	_, err = trS.readPacket()

--- a/ssh/kex.go
+++ b/ssh/kex.go
@@ -20,21 +20,21 @@ import (
 )
 
 const (
-	kexAlgoDH1SHA1                = "diffie-hellman-group1-sha1"
-	kexAlgoDH14SHA1               = "diffie-hellman-group14-sha1"
-	kexAlgoDH14SHA256             = "diffie-hellman-group14-sha256"
-	kexAlgoDH16SHA512             = "diffie-hellman-group16-sha512"
-	kexAlgoECDH256                = "ecdh-sha2-nistp256"
-	kexAlgoECDH384                = "ecdh-sha2-nistp384"
-	kexAlgoECDH521                = "ecdh-sha2-nistp521"
-	kexAlgoCurve25519SHA256LibSSH = "curve25519-sha256@libssh.org"
-	kexAlgoCurve25519SHA256       = "curve25519-sha256"
+	KexAlgoDH1SHA1                = "diffie-hellman-group1-sha1"
+	KexAlgoDH14SHA1               = "diffie-hellman-group14-sha1"
+	KexAlgoDH14SHA256             = "diffie-hellman-group14-sha256"
+	KexAlgoDH16SHA512             = "diffie-hellman-group16-sha512"
+	KexAlgoECDH256                = "ecdh-sha2-nistp256"
+	KexAlgoECDH384                = "ecdh-sha2-nistp384"
+	KexAlgoECDH521                = "ecdh-sha2-nistp521"
+	KexAlgoCurve25519SHA256LibSSH = "curve25519-sha256@libssh.org"
+	KexAlgoCurve25519SHA256       = "curve25519-sha256"
 
 	// For the following kex only the client half contains a production
 	// ready implementation. The server half only consists of a minimal
 	// implementation to satisfy the automated tests.
-	kexAlgoDHGEXSHA1   = "diffie-hellman-group-exchange-sha1"
-	kexAlgoDHGEXSHA256 = "diffie-hellman-group-exchange-sha256"
+	KexAlgoDHGEXSHA1   = "diffie-hellman-group-exchange-sha1"
+	KexAlgoDHGEXSHA256 = "diffie-hellman-group-exchange-sha256"
 )
 
 // kexResult captures the outcome of a key exchange.
@@ -405,7 +405,7 @@ func init() {
 	// This is the group called diffie-hellman-group1-sha1 in
 	// RFC 4253 and Oakley Group 2 in RFC 2409.
 	p, _ := new(big.Int).SetString("FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFF", 16)
-	kexAlgoMap[kexAlgoDH1SHA1] = &dhGroup{
+	kexAlgoMap[KexAlgoDH1SHA1] = &dhGroup{
 		g:        new(big.Int).SetInt64(2),
 		p:        p,
 		pMinus1:  new(big.Int).Sub(p, bigOne),
@@ -422,11 +422,11 @@ func init() {
 		pMinus1: new(big.Int).Sub(p, bigOne),
 	}
 
-	kexAlgoMap[kexAlgoDH14SHA1] = &dhGroup{
+	kexAlgoMap[KexAlgoDH14SHA1] = &dhGroup{
 		g: group14.g, p: group14.p, pMinus1: group14.pMinus1,
 		hashFunc: crypto.SHA1,
 	}
-	kexAlgoMap[kexAlgoDH14SHA256] = &dhGroup{
+	kexAlgoMap[KexAlgoDH14SHA256] = &dhGroup{
 		g: group14.g, p: group14.p, pMinus1: group14.pMinus1,
 		hashFunc: crypto.SHA256,
 	}
@@ -435,20 +435,20 @@ func init() {
 	// 8268 and Oakley Group 16 in RFC 3526.
 	p, _ = new(big.Int).SetString("FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D670C354E4ABC9804F1746C08CA18217C32905E462E36CE3BE39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF6955817183995497CEA956AE515D2261898FA051015728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6BF12FFA06D98A0864D87602733EC86A64521F2B18177B200CBBE117577A615D6C770988C0BAD946E208E24FA074E5AB3143DB5BFCE0FD108E4B82D120A92108011A723C12A787E6D788719A10BDBA5B2699C327186AF4E23C1A946834B6150BDA2583E9CA2AD44CE8DBBBC2DB04DE8EF92E8EFC141FBECAA6287C59474E6BC05D99B2964FA090C3A2233BA186515BE7ED1F612970CEE2D7AFB81BDD762170481CD0069127D5B05AA993B4EA988D8FDDC186FFB7DC90A6C08F4DF435C934063199FFFFFFFFFFFFFFFF", 16)
 
-	kexAlgoMap[kexAlgoDH16SHA512] = &dhGroup{
+	kexAlgoMap[KexAlgoDH16SHA512] = &dhGroup{
 		g:        new(big.Int).SetInt64(2),
 		p:        p,
 		pMinus1:  new(big.Int).Sub(p, bigOne),
 		hashFunc: crypto.SHA512,
 	}
 
-	kexAlgoMap[kexAlgoECDH521] = &ecdh{elliptic.P521()}
-	kexAlgoMap[kexAlgoECDH384] = &ecdh{elliptic.P384()}
-	kexAlgoMap[kexAlgoECDH256] = &ecdh{elliptic.P256()}
-	kexAlgoMap[kexAlgoCurve25519SHA256] = &curve25519sha256{}
-	kexAlgoMap[kexAlgoCurve25519SHA256LibSSH] = &curve25519sha256{}
-	kexAlgoMap[kexAlgoDHGEXSHA1] = &dhGEXSHA{hashFunc: crypto.SHA1}
-	kexAlgoMap[kexAlgoDHGEXSHA256] = &dhGEXSHA{hashFunc: crypto.SHA256}
+	kexAlgoMap[KexAlgoECDH521] = &ecdh{elliptic.P521()}
+	kexAlgoMap[KexAlgoECDH384] = &ecdh{elliptic.P384()}
+	kexAlgoMap[KexAlgoECDH256] = &ecdh{elliptic.P256()}
+	kexAlgoMap[KexAlgoCurve25519SHA256] = &curve25519sha256{}
+	kexAlgoMap[KexAlgoCurve25519SHA256LibSSH] = &curve25519sha256{}
+	kexAlgoMap[KexAlgoDHGEXSHA1] = &dhGEXSHA{hashFunc: crypto.SHA1}
+	kexAlgoMap[KexAlgoDHGEXSHA256] = &dhGEXSHA{hashFunc: crypto.SHA256}
 }
 
 // curve25519sha256 implements the curve25519-sha256 (formerly known as

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -488,7 +488,49 @@ func (r *rsaPublicKey) Verify(data []byte, sig *Signature) error {
 	h := hash.New()
 	h.Write(data)
 	digest := h.Sum(nil)
-	return rsa.VerifyPKCS1v15((*rsa.PublicKey)(r), hash, digest, sig.Blob)
+
+	// Signatures in PKCS1v15 must match the key's modulus in
+	// length. However with SSH, some signers provide RSA
+	// signatures which are missing the MSB 0's of the bignum
+	// represented. With ssh-rsa signatures, this is encouraged by
+	// the spec (even though e.g. OpenSSH will give the full
+	// length unconditionally). With rsa-sha2-* signatures, the
+	// verifier is allowed to support these, even though they are
+	// out of spec. See RFC 4253 Section 6.6 for ssh-rsa and RFC
+	// 8332 Section 3 for rsa-sha2-* details.
+	//
+	// In practice:
+	// * OpenSSH always allows "short" signatures:
+	//   https://github.com/openssh/openssh-portable/blob/V_9_8_P1/ssh-rsa.c#L526
+	//   but always generates padded signatures:
+	//   https://github.com/openssh/openssh-portable/blob/V_9_8_P1/ssh-rsa.c#L439
+	//
+	// * PuTTY versions 0.81 and earlier will generate short
+	//   signatures for all RSA signature variants. Note that
+	//   PuTTY is embedded in other software, such as WinSCP and
+	//   FileZilla. At the time of writing, a patch has been
+	//   applied to PuTTY to generate padded signatures for
+	//   rsa-sha2-*, but not yet released:
+	//   https://git.tartarus.org/?p=simon/putty.git;a=commitdiff;h=a5bcf3d384e1bf15a51a6923c3724cbbee022d8e
+	//
+	// * SSH.NET versions 2024.0.0 and earlier will generate short
+	//   signatures for all RSA signature variants, fixed in 2024.1.0:
+	//   https://github.com/sshnet/SSH.NET/releases/tag/2024.1.0
+	//
+	// As a result, we pad these up to the key size by inserting
+	// leading 0's.
+	//
+	// Note that support for short signatures with rsa-sha2-* may
+	// be removed in the future due to such signatures not being
+	// allowed by the spec.
+	blob := sig.Blob
+	keySize := (*rsa.PublicKey)(r).Size()
+	if len(blob) < keySize {
+		padded := make([]byte, keySize)
+		copy(padded[keySize-len(blob):], blob)
+		blob = padded
+	}
+	return rsa.VerifyPKCS1v15((*rsa.PublicKey)(r), hash, digest, blob)
 }
 
 func (r *rsaPublicKey) CryptoPublicKey() crypto.PublicKey {

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -547,7 +547,7 @@ func checkDSAParams(param *dsa.Parameters) error {
 	// SSH specifies FIPS 186-2, which only provided a single size
 	// (1024 bits) DSA key. FIPS 186-3 allows for larger key
 	// sizes, which would confuse SSH.
-	if l := param.P.BitLen(); l != 1024 {
+	if l := param.P.BitLen(); l != 1024 && l != 2048 {
 		return fmt.Errorf("ssh: unsupported DSA key size %d", l)
 	}
 

--- a/ssh/messages.go
+++ b/ssh/messages.go
@@ -43,10 +43,6 @@ type disconnectMsg struct {
 	Language string
 }
 
-func (d *disconnectMsg) Error() string {
-	return fmt.Sprintf("ssh: disconnect, reason %d: %s", d.Reason, d.Message)
-}
-
 // See RFC 4253, section 7.1.
 const msgKexInit = 20
 

--- a/ssh/messages.go
+++ b/ssh/messages.go
@@ -202,12 +202,20 @@ type channelOpenMsg struct {
 	TypeSpecificData []byte `ssh:"rest"`
 }
 
-const msgChannelExtendedData = 95
 const msgChannelData = 94
 
 // Used for debug print outs of packets.
 type channelDataMsg struct {
 	PeersID uint32 `sshtype:"94"`
+	Length  uint32
+	Rest    []byte `ssh:"rest"`
+}
+
+const msgChannelExtendedData = 95
+
+type channelExtendedDataMsg struct {
+	PeersID uint32 `sshtype:"95"`
+	Type    uint32
 	Length  uint32
 	Rest    []byte `ssh:"rest"`
 }
@@ -826,6 +834,8 @@ func decode(packet []byte) (interface{}, error) {
 		msg = new(channelOpenMsg)
 	case msgChannelData:
 		msg = new(channelDataMsg)
+	case msgChannelExtendedData:
+		msg = new(channelExtendedDataMsg)
 	case msgChannelOpenConfirm:
 		msg = new(channelOpenConfirmMsg)
 	case msgChannelOpenFailure:
@@ -876,6 +886,7 @@ var packetTypeNames = map[byte]string{
 	msgRequestFailure:      "globalRequestFailureMsg",
 	msgChannelOpen:         "channelOpenMsg",
 	msgChannelData:         "channelDataMsg",
+	msgChannelExtendedData: "channelExtendedDataMsg",
 	msgChannelOpenConfirm:  "channelOpenConfirmMsg",
 	msgChannelOpenFailure:  "channelOpenFailureMsg",
 	msgChannelWindowAdjust: "windowAdjustMsg",

--- a/ssh/mux.go
+++ b/ssh/mux.go
@@ -178,6 +178,10 @@ func (m *mux) ackRequest(ok bool, data []byte) error {
 	return m.sendMessage(globalRequestFailureMsg{Data: data})
 }
 
+func (m *mux) Disconnect(reason DisconnectReason, message string) error {
+	return m.sendMessage(disconnectMsg{Reason: uint32(reason), Message: message})
+}
+
 func (m *mux) Close() error {
 	return m.conn.Close()
 }

--- a/ssh/mux.go
+++ b/ssh/mux.go
@@ -178,10 +178,6 @@ func (m *mux) ackRequest(ok bool, data []byte) error {
 	return m.sendMessage(globalRequestFailureMsg{Data: data})
 }
 
-func (m *mux) Disconnect(reason DisconnectReason, message string) error {
-	return m.sendMessage(disconnectMsg{Reason: uint32(reason), Message: message})
-}
-
 func (m *mux) Close() error {
 	return m.conn.Close()
 }

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -511,7 +511,8 @@ userAuthLoop:
 				return nil, err
 			}
 
-			return nil, discMsg
+			err := &DisconnectError{Reason: DisconnectReason(discMsg.Reason), Message: discMsg.Message}
+			return nil, err
 		}
 
 		var userAuthReq userAuthRequestMsg

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -829,6 +829,9 @@ userAuthLoop:
 			}
 		}
 
+		if config.NoClientAuthCallback != nil {
+			failureMsg.Methods = append(failureMsg.Methods, "none")
+		}
 		if authConfig.PasswordCallback != nil {
 			failureMsg.Methods = append(failureMsg.Methods, "password")
 		}

--- a/ssh/server_test.go
+++ b/ssh/server_test.go
@@ -211,7 +211,7 @@ func TestNewServerConnValidationErrors(t *testing.T) {
 
 	serverConf = &ServerConfig{
 		Config: Config{
-			KeyExchanges: []string{kexAlgoDHGEXSHA256},
+			KeyExchanges: []string{KexAlgoDHGEXSHA256},
 		},
 	}
 	c = &markerConn{}

--- a/ssh/transport.go
+++ b/ssh/transport.go
@@ -173,7 +173,8 @@ func (s *connectionState) readPacket(r *bufio.Reader, strictMode bool) ([]byte, 
 			if err := Unmarshal(packet, &msg); err != nil {
 				return nil, err
 			}
-			return nil, &msg
+			err := &DisconnectError{Reason: DisconnectReason(msg.Reason), Message: msg.Message}
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
The server will always advertise the ping extension to clients.  When proxying connections we can run into situations where the proxy server connection negotiates ping support - however our remote server is not able to fulfill this.  This causes proxied messages to fail, terminating the session.

For the implementation seen here, I've looked to minimize the changes required to the existing crypto/ssh code to aid future maintenance work.